### PR TITLE
Fixed issue #81

### DIFF
--- a/src/components/AddArticleDialog.js
+++ b/src/components/AddArticleDialog.js
@@ -37,6 +37,14 @@ Date.prototype.toDatetimeLocal = function toDatetimeLocal() {
   return YYYY + '-' + MM + '-' + DD + 'T' + HH + ':' + II + ':' + SS;
 };
 
+// Converts the dates in the values object for the form into UTC
+const convertDatesInValuestoUTC = (values) => {
+  return {
+    ...values,
+    adate: new Date(values.adate).toISOString()
+  };
+};
+
 const useStyles = makeStyles(theme => ({
   appBar: {
     position: 'relative',
@@ -103,10 +111,7 @@ export const AddArticleDialog = props => {
   };
 
   const handleSubmit = () => {
-    const requestData = {
-      ...values,
-      adate: new Date(values.adate).toISOString()
-    };
+    const requestData = convertDatesInValuestoUTC();
     if (props.edit === true) {
       axios
         .put(hostname + '/api/article/' + props.data.arid, requestData, {

--- a/src/components/AddArticleDialog.js
+++ b/src/components/AddArticleDialog.js
@@ -103,10 +103,13 @@ export const AddArticleDialog = props => {
   };
 
   const handleSubmit = () => {
-    console.log(values);
+    const requestData = {
+      ...values,
+      adate: new Date(values.adate).toISOString()
+    };
     if (props.edit === true) {
       axios
-        .put(hostname + '/api/article/' + props.data.arid, values, {
+        .put(hostname + '/api/article/' + props.data.arid, requestData, {
           headers: {
             'Content-Type': 'application/json',
             'Authorization': 'Bearer ' + localStorage.getItem('atoken'),
@@ -125,7 +128,7 @@ export const AddArticleDialog = props => {
         });
     } else {
       axios
-        .post(hostname + '/api/article', values, {
+        .post(hostname + '/api/article', requestData, {
           headers: {
             'Content-Type': 'application/json',
             'Authorization': 'Bearer ' + localStorage.getItem('atoken'),

--- a/src/components/AddArticleDialog.js
+++ b/src/components/AddArticleDialog.js
@@ -20,6 +20,7 @@ import { Close } from '@material-ui/icons';
 import EditArticle from './EditArticle';
 import { ecats, hostname } from '../links';
 import axios from 'axios';
+import { convertDatesinValuestoUTC } from '../utils';
 
 //Nice prototype to convert Date objects to datetime local strings
 // eslint-disable-next-line
@@ -35,14 +36,6 @@ Date.prototype.toDatetimeLocal = function toDatetimeLocal() {
     II = ten(date.getMinutes()),
     SS = ten(date.getSeconds());
   return YYYY + '-' + MM + '-' + DD + 'T' + HH + ':' + II + ':' + SS;
-};
-
-// Converts the dates in the values object for the form into UTC
-const convertDatesInValuestoUTC = (values) => {
-  return {
-    ...values,
-    adate: new Date(values.adate).toISOString()
-  };
 };
 
 const useStyles = makeStyles(theme => ({
@@ -111,7 +104,7 @@ export const AddArticleDialog = props => {
   };
 
   const handleSubmit = () => {
-    const requestData = convertDatesInValuestoUTC();
+    const requestData = convertDatesinValuestoUTC(values, ['adate']);
     if (props.edit === true) {
       axios
         .put(hostname + '/api/article/' + props.data.arid, requestData, {

--- a/src/components/AddEventDialog.js
+++ b/src/components/AddEventDialog.js
@@ -21,6 +21,7 @@ import React, { useState, useEffect } from 'react';
 import { ecats, hostname } from '../links';
 import Alert from '@material-ui/lab/Alert';
 import { CircularProgress } from '@material-ui/core';
+import { convertDatesinValuestoUTC } from '../utils';
 const useStyles = makeStyles(theme => ({
   root: {
     position: 'absolute',
@@ -49,17 +50,6 @@ Date.prototype.toDatetimeLocal = function toDatetimeLocal() {
     II = ten(date.getMinutes()),
     SS = ten(date.getSeconds());
   return YYYY + '-' + MM + '-' + DD + 'T' + HH + ':' + II + ':' + SS;
-};
-
-// Converts the dates in the values object for the form into UTC
-const convertDatesInValuestoUTC = (values) => {
-  return {
-    ...values,
-    eventstart: new Date(values.eventstart).toISOString(),
-    eventend: new Date(values.eventend).toISOString(),
-    pubstart: new Date(values.pubstart).toISOString(),
-    pubend: new Date(values.pubend).toISOString()
-  };
 };
 
 export const AddEventDialog = props => {
@@ -129,7 +119,7 @@ export const AddEventDialog = props => {
 
   const submitData = () => {
     props.onClose();
-    const requestData = convertDatesInValuestoUTC(values);
+    const requestData = convertDatesinValuestoUTC(values, ['eventstart', 'eventend', 'pubstart', 'pubend']);
     if (props.edit === true) {
       axios
         .put(hostname + '/api/event/' + props.data.eid, requestData, {

--- a/src/components/AddEventDialog.js
+++ b/src/components/AddEventDialog.js
@@ -51,6 +51,17 @@ Date.prototype.toDatetimeLocal = function toDatetimeLocal() {
   return YYYY + '-' + MM + '-' + DD + 'T' + HH + ':' + II + ':' + SS;
 };
 
+// Converts the dates in the values object for the form into UTC
+const convertDatesInValuestoUTC = (values) => {
+  return {
+    ...values,
+    eventstart: new Date(values.eventstart).toISOString(),
+    eventend: new Date(values.eventend).toISOString(),
+    pubstart: new Date(values.pubstart).toISOString(),
+    pubend: new Date(values.pubend).toISOString()
+  };
+};
+
 export const AddEventDialog = props => {
   const classes = useStyles();
 
@@ -118,13 +129,7 @@ export const AddEventDialog = props => {
 
   const submitData = () => {
     props.onClose();
-    const requestData = {
-      ...values,
-      eventstart: new Date(values.eventstart).toISOString(),
-      eventend: new Date(values.eventend).toISOString(),
-      pubstart: new Date(values.pubstart).toISOString(),
-      pubend: new Date(values.pubend).toISOString(),
-    };
+    const requestData = convertDatesInValuestoUTC(values);
     if (props.edit === true) {
       axios
         .put(hostname + '/api/event/' + props.data.eid, requestData, {

--- a/src/components/AddEventDialog.js
+++ b/src/components/AddEventDialog.js
@@ -118,9 +118,14 @@ export const AddEventDialog = props => {
 
   const submitData = () => {
     props.onClose();
+    const requestData = {
+      ...values,
+      eventstart: new Date(values.eventstart).toISOString(),
+      eventend: new Date(values.eventend).toISOString()
+    };
     if (props.edit === true) {
       axios
-        .put(hostname + '/api/event/' + props.data.eid, values, {
+        .put(hostname + '/api/event/' + props.data.eid, requestData, {
           headers: {
             'Content-Type': 'application/json',
             'Authorization': 'Bearer ' + localStorage.getItem('atoken'),
@@ -139,7 +144,7 @@ export const AddEventDialog = props => {
         });
     } else {
       axios
-        .post(hostname + '/api/event', values, {
+        .post(hostname + '/api/event', requestData, {
           headers: {
             'Content-Type': 'application/json',
             'Authorization': 'Bearer ' + localStorage.getItem('atoken'),

--- a/src/components/AddEventDialog.js
+++ b/src/components/AddEventDialog.js
@@ -121,7 +121,9 @@ export const AddEventDialog = props => {
     const requestData = {
       ...values,
       eventstart: new Date(values.eventstart).toISOString(),
-      eventend: new Date(values.eventend).toISOString()
+      eventend: new Date(values.eventend).toISOString(),
+      pubstart: new Date(values.pubstart).toISOString(),
+      pubend: new Date(values.pubend).toISOString(),
     };
     if (props.edit === true) {
       axios

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,15 @@
+/**
+ * Converts date values in an object to UTC, based on list of keys provided
+ * @param {*} object Input object to process
+ * @param {*} keys Keys that have date values in object
+ * @returns New object with the values of the keys converted to UTC
+ */
+export function convertDatesinValuestoUTC(object, keys) {
+    const result = { ...object };
+    keys.forEach((key) => {
+        if (result[key]) {
+            result[key] = new Date(result[key]).toISOString();
+        }
+    });
+    return result;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 /**
  * Converts date values in an object to UTC, based on list of keys provided
- * @param {*} object Input object to process
- * @param {*} keys Keys that have date values in object
+ * @param {Object} object Input object to process
+ * @param {String[]} keys Keys that have date values in object
  * @returns New object with the values of the keys converted to UTC
  */
 export function convertDatesinValuestoUTC(object, keys) {


### PR DESCRIPTION
The frontend converts the time object to local time so that the user can read and enter in the date field correctly. On sending this data to the backend, the backend server does a new Date(date) which assumes the time it got is UTC, and simply uses the local time we sent as UTC time. When frontend receives this for the event, we display it as +5:30 of the received time because we got time as UTC.

To avoid this problem, just before submission the values had to be modified to UTC string as the frontend as info about the timezone of the user. Backend does not have that info and should only get UTC, else the logic breaks. This was fixed in this PR, to make sure we only send UTC.