### PR TITLE
fix: added more accurate type infering in convertDatesinValuestoUTC method

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,15 +1,16 @@
 /**
  * Converts date values in an object to UTC, based on list of keys provided
- * @param {Object} object Input object to process
- * @param {String[]} keys Keys that have date values in object
+ * @template T
+ * @param {T} object Input object to process
+ * @param {(keyof T)[]} keys Keys that have date values in object
  * @returns New object with the values of the keys converted to UTC
  */
 export function convertDatesinValuestoUTC(object, keys) {
-    const result = { ...object };
-    keys.forEach((key) => {
-        if (result[key]) {
-            result[key] = new Date(result[key]).toISOString();
-        }
-    });
-    return result;
+  const result = { ...object };
+  keys.forEach(key => {
+    if (result[key]) {
+      result[key] = new Date(result[key]).toISOString();
+    }
+  });
+  return result;
 }


### PR DESCRIPTION
- This is a very small PR, the JsDoc type is wrong, if the obj type is `<T>` then type of keys should be the `keyof T`.

- I've updated the keys parameter to be of type `(keyof T)[]`, which means it's an array of keys from the T object. This should allow  to pass in an array of strings that match the keys in the values object.